### PR TITLE
Bundle Theme Customisations

### DIFF
--- a/assets/addToCartScript.js
+++ b/assets/addToCartScript.js
@@ -1,0 +1,91 @@
+// addToCartScript.js
+
+window.addEventListener('DOMContentLoaded', (e)=> {
+    init()
+})
+
+/* initialize */
+const init = () => {
+    console.log('DOM fully loaded and parsed.')
+    // disable add to cart button before users make any selection choice
+    enableAddToCart(false)
+    /* listen to the change event on all selects */
+    document.querySelectorAll('.bundle-select').forEach( elem => {
+        elem.addEventListener('change', selectCallback)
+    })
+    /* attach form submit callback */
+    document.querySelector('.product-single form').addEventListener('submit', addToCartCallback)
+}
+
+/* enable add to cart button if enable=true; otherwise, disable the button */
+const enableAddToCart = (enable) => {
+    const btnAddToCart = document.getElementById('AddToCart')     
+    btnAddToCart.disabled = !enable
+}
+
+/* the callback function to handle select event */
+const selectCallback = () => {
+    let allSelected = true
+    document.querySelectorAll('.bundle-select').forEach( elem => {
+        // check whether any select has not been made by user - value is empty
+        if(!elem.value) allSelected = false
+    })
+    // enable add to cart button when allSelected is true; otherwise, disable the button again
+    enableAddToCart(allSelected)
+}
+
+/* add to cart callback */
+const addToCartCallback = (e) => {
+    e.preventDefault()
+    
+    
+    // get the bundle product variant ID
+    const bundleProductVariantId = document.querySelector('.product-single__variants').value
+    //get the bundle items' variant IDs selected by user
+    let bundleItemsVariantIds = []
+    document.querySelectorAll('.bundle-select').forEach( elem => {
+        bundleItemsVariantIds.push(Number(elem.value))
+    } )
+
+    // push in the bundle product variant as the 1st cart line item
+    let data= {
+        items: [
+            {
+                id: bundleProductVariantId,
+                properties: {
+                    '_is_bundle': 'yes',
+                    '_bundle_items_variants': bundleItemsVariantIds
+                }
+            }
+        ]
+    }
+
+    // push in the bundle items variants as the other cart line items
+    bundleItemsVariantIds.forEach( variantId => {
+        data.items.push({
+            id: variantId,
+            properties: {
+                '_is_bundle_item': 'yes'
+            }
+        })
+    })
+
+    console.log(data)
+
+    // use AJAX API to add multiple variants into cart
+    fetch('/cart/add.js',{
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    })
+    .then( res => res.json())
+    .then( json => {
+        // redirect user to cart
+        window.location.href='/cart'
+    })
+    .catch( error => {
+        console.log('Error: ', error)
+    } )
+}

--- a/assets/updateCartScript.js
+++ b/assets/updateCartScript.js
@@ -1,0 +1,64 @@
+// updateCartScript.js
+window.addEventListener('DOMContentLoaded', (e)=> {
+    initBundleRemoveButtons()
+
+    initBundleQuantitySelector()
+
+})
+
+/* Initialize the remove buttons in cart page */
+const initBundleRemoveButtons = () => {
+    const removeButtons = document.querySelectorAll('.cart__remove')
+    removeButtons.forEach( btn => {
+        if(btn.dataset.productType=='bundle'){
+            // initialize AJAX POST data to cart/update.js
+            data = { updates: {
+            } } 
+            // read out all the variant IDs related to the bundle - for both the bundle itself and the bundle items
+            const variantIds = btn.dataset.variants.split(',')
+            // build POST data. Reference: https://shopify.dev/docs/themes/ajax-api/reference/cart#post-cart-update-js
+            variantIds.forEach( id => {
+                data.updates[id] = 0
+            })
+            // listen to button click event
+            btn.addEventListener('click', (e)=> {
+                e.preventDefault()
+                // make AJAX POST at cart/update.js
+                fetch('/cart/update.js',{
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(data)
+                })
+                .then( res => res.json())
+                .then( json => {
+                    // redirect user to cart
+                    window.location.href='/cart'
+                })
+                .catch( error => {
+                    console.log('Error: ', error)
+                } )
+            })
+        }
+    })
+}
+
+
+/* Initialize the quantity selector in cart for bundle */
+const initBundleQuantitySelector = () => {
+    const bundleQuantitySelectors = document.querySelectorAll('input.cart__quantity-selector.bundle-quantity')
+    bundleQuantitySelectors.forEach( bundleQuantitySelector => {
+        let bundleId = bundleQuantitySelector.dataset.bundleId
+        bundleQuantitySelector.addEventListener('change', (e)=>{
+            // read out the up-to-date quantity of the bundle selected by the user in cart
+            let bundleQuantity = e.target.value
+            // Select the items belonging to the same bundle
+            const bundleItemQuantitySelectors = [...document.querySelectorAll('input.cart__quantity-selector.bundle-item-quantity')].filter( selector => selector.dataset.bundleId == bundleId )
+            // Sync the items' quantity with the same bundle quantity
+            bundleItemQuantitySelectors.forEach( bundleItemQuantitySelector => {
+                bundleItemQuantitySelector.value = bundleQuantity
+            })
+        })
+    })
+}

--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -51,5 +51,6 @@
 
     {{ tracking_code }}
 
+    {% render 'checkout-bundle', checkout: checkout %}
   </body>
 </html>

--- a/sections/cart-template.liquid
+++ b/sections/cart-template.liquid
@@ -34,7 +34,15 @@
         Loop through products in the cart
       {% endcomment %}
       {% for item in cart.items %}
+        {% comment %} Check whether it is a bundle item and capture the boolean flag value {% endcomment %}
+        {% assign item_properties = item.properties | join: ',' %}
+        {% if item_properties contains "_is_bundle_item" %}
+          {% assign is_bundle_item = true %}
+        {% else %}
+          {% assign is_bundle_item = false %}
+        {% endif %}
 
+        {% unless is_bundle_item %}
           <div class="cart__row">
             <div class="grid--full cart__row--table-large">
 
@@ -108,12 +116,20 @@
 
                         {% endunless %}
 
+                        {% comment %} If the item is a bundle product, read out the variant IDs of the bundle items from the bundle's properties {% endcomment %}
+                        {% if p.first == '_bundle_items_variants' %}
+                          {% assign bundle_items_variants = p.last | remove: '[' | remove: ']' | remove: ' ' %}
+                        {% endif %}
 
                       {% endfor %}
                     {% endif %}
 
                     <a href="{{ routes.cart_change_url }}?line={{ forloop.index }}&amp;quantity=0" 
                     class="cart__remove"
+                    {% if item.product.type=='bundle' %}
+                      data-product-type="bundle"
+                      data-variants='{{ item.variant_id | append: "," | append: bundle_items_variants }}'
+                    {% endif %}
                     >
                       <small>{{ 'cart.general.remove' | t }}</small>
                     </a>
@@ -153,7 +169,13 @@
 
                   <div class="grid__item one-quarter one-half medium-down--one-third text-center">
                     <label for="updates_{{ item.key }}" class="cart__mini-labels">{{ 'cart.label.quantity' | t }}</label>
+                    {% if item.product.type == 'bundle' %}
+                      {% render 'cart-bundle-quantity-selector', item: item, bundle_items_variants: bundle_items_variants %}
+                    {% elsif is_bundle_item == true %}
+                      {% comment %} No quantity input for user to select for bundle items {% endcomment %}
+                    {% else %}
                       <input type="number" class="cart__quantity-selector" name="updates[{{ item.variant_id }}]" id="updates_{{ item.key }}" value="{{ item.quantity }}" min="0" aria-label="{{ 'cart.label.quantity' | t }}">
+                    {% endif %}
                   </div>
 
                   <div class="grid__item one-quarter one-half medium-down--one-third text-right">
@@ -184,6 +206,7 @@
 
             </div>
           </div>
+        {% endunless %}
       {% endfor %}
 
       <div class="cart__row">
@@ -266,6 +289,8 @@
   {% endif %}
 </div>
 
+{% comment %} Load custom JS code to handle cart update AJAX for bundle(s) {% endcomment %}
+{{ 'updateCartScript.js' |  asset_url | script_tag }}
 
 
 {% schema %}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -113,7 +113,8 @@
             <a href="{{ routes.cart_url }}" class="cart-page-link">
               {{ 'layout.cart.title' | t }}{% unless cart.item_count == 0 %}:{% endunless %}
               <span class="cart-count header-bar__cart-count{% if cart.item_count == 0 %} hidden-count{% endif %}">
-                {{ cart.item_count }}
+                {% comment %} {{ cart.item_count }} {% endcomment %}
+                {% render 'cart-item-count' %}
               </span>
             </a>
           </div>

--- a/sections/product-template.liquid
+++ b/sections/product-template.liquid
@@ -204,6 +204,9 @@
               {% endfor %}
             </select>
 
+            {% if product.type == 'bundle' %}
+              {% render 'bundle-selector', bundle_collection: product.metafields.my_fields.bundle_collection_id %}
+            {% endif %}
 
             <div class="product-single__quantity{% unless section.settings.product_quantity_enable %} is-hidden{% endunless %}">
               <label for="Quantity">{{ 'products.product.quantity' | t }}</label>
@@ -214,10 +217,15 @@
               <span id="AddToCartText">{{ 'products.product.add_to_cart' | t }}</span>
             </button>
 
+            {% comment %} 
               {% if section.settings.enable_payment_button %}
                 {{ form | payment_button }}
               {% endif %} 
+            {% endcomment %}
 
+            {% if product.type == 'bundle' %}
+              {{ 'addToCartScript.js' |  asset_url | script_tag }}
+            {% endif %}
 
           {% endform %}
 

--- a/snippets/bundle-selector.liquid
+++ b/snippets/bundle-selector.liquid
@@ -1,0 +1,13 @@
+
+{% for bundle_item in product.metafields.bundle_items %}
+{% assign current_bundle_item = bundle_item.last.value %}
+  <label for="{{ current_bundle_item.title }}">{{ current_bundle_item.title }}:</label>
+  <select name="{{ current_bundle_item.title }}" id="{{ current_bundle_item.id }}" class="bundle-select">
+    <option value="" selected>Please select</option>
+    {% for variant in current_bundle_item.variants %}
+    <option value="{{ variant.id }}">{{ variant.title }} - {{ variant.price | money_with_currency }}</option>
+    {% endfor %}
+  </select>
+{% endfor %}
+
+

--- a/snippets/cart-bundle-quantity-selector.liquid
+++ b/snippets/cart-bundle-quantity-selector.liquid
@@ -1,0 +1,32 @@
+{% comment %} 
+    @item - the cart item object passed in
+    @bundle_items_variants - the variant IDs of the bundle items in a string
+{% endcomment %}
+
+
+{% if item.product.type =='bundle' and bundle_items_variants != blank %}
+    {% comment %} Generate a normal quantity selector for bundle product itself {% endcomment %}
+    <input 
+    type="number"
+    class="cart__quantity-selector bundle-quantity" 
+    name="updates[{{ item.variant_id }}]" 
+    id="updates_{{ item.key }}" 
+    value="{{ item.quantity }}" 
+    min="0" 
+    aria-label="{{ 'cart.label.quantity' | t }}"
+    data-bundle-id="{{ item.variant_id }}">
+
+    {% comment %} Generate hidden inputs for bundle item quantities {% endcomment %}
+    {% assign bundle_items_variants = bundle_items_variants | split : ',' %}
+    {% for variant_id in bundle_items_variants %}
+        <input 
+        type="hidden"
+        class="cart__quantity-selector bundle-item-quantity" 
+        name="updates[{{ variant_id }}]" 
+        id="updates_{{ variant_id }}" 
+        value="{{ item.quantity }}" 
+        min="0" 
+        aria-label="{{ 'cart.label.quantity' | t }}"
+        data-bundle-id="{{ item.variant_id }}">
+    {% endfor %}
+{% endif %}

--- a/snippets/cart-item-count.liquid
+++ b/snippets/cart-item-count.liquid
@@ -1,0 +1,16 @@
+{% comment %}
+    1) return the original cart item count, when there is only 1 or 0 item in cart
+    2) otherwise, check if any bundle item exists in cart; If yes, deduct them from cart item quantity
+{% endcomment %}
+
+{% if cart.item_count <= 1 %}
+    {{ cart.item_count }}
+{% else %}
+    {% assign cart_item_count = cart.item_count %}
+    {% for item in cart.items %}
+        {% if item.properties['_is_bundle_item'] == 'yes' %}
+            {% assign cart_item_count = cart_item_count | minus: item.quantity %}
+        {% endif %}
+    {% endfor %}
+    {{ cart_item_count }}
+{% endif %}

--- a/snippets/checkout-bundle.liquid
+++ b/snippets/checkout-bundle.liquid
@@ -1,0 +1,40 @@
+{% comment %} 
+    Loop through each item and its property to see whether it is a bundle item; 
+    If it is, use JS code to match its variant ID and hide it from checkout page. 
+{% endcomment %}
+
+{% for item in checkout.line_items %}
+    {% assign propertySize = item.properties | size %}
+    {% if propertySize > 0 %}
+        {% for p in item.properties %}
+            {% if p.first == '_is_bundle_item' and p.last == 'yes' %}   
+                <div hidden class="bundle-item-variant-id">{{ item.variant_id }}</div>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endfor %}
+
+
+<script>
+    (function($){
+        $(document).on(`page:load page:change`, () => {
+            /** 
+             * Select all cart items displayed as HTML elements in a table in checkout page.
+             * Using vanilla JS syntax, as jQuery's each() function seems not working for the table rows here
+             */
+            let cartItemsTableRows = document.querySelectorAll('tr.product')
+            
+            /** 
+             * For each bundle item we have detected from checkout object in liquid, 
+             * hide the corresponding item HTML table row in the checkout page with hidden attribute.
+             */
+            document.querySelectorAll('.bundle-item-variant-id').forEach( bundleItem => {
+                let bundleItemVariantId = bundleItem.innerText
+                cartItemsTableRows.forEach( tr => {
+                    if(tr.dataset.variantId == bundleItemVariantId)
+                        tr.setAttribute('hidden', true)
+                })
+            })
+        })        
+    })(Checkout.$)
+</script>


### PR DESCRIPTION
Bundle Theme Customisations... [See files changed here](https://github.com/darryn/minimal-bundling/pull/3/files).

## Disclaimer

This is now an outdated way to handle bundles. Proceed knowing that you may have to change your approach to bundles in time as better methods are developed.

## Note...

* This assumes that there is a "master" product with a type of `bundle`
* The master product is what controls the display price on the product page - https://screenshot.click/25-32-vgz2w-26dj6.png
* This approach expects each bundle product reference metafield to have the namespace of `bundle_items` - https://screenshot.click/25-34-nm6hd-5kogy.png
* This approach uses a separate metafield for each piece of the bundle, but can now use a single metafield which allows the reference to multiple products - https://screenshot.click/25-35-pg19z-mlbxn.png
* To apply the necessary discount to the bundle, you will need a [Line Item Script](https://help.shopify.com/en/manual/checkout-settings/script-editor) (**referenced below**)
* To change how the bundles are represented in the checkout, there is a portion to this which includes a `checkout.liquid` customisation
* **What isn't covered** here is the necessary updates to the order/shipping confirmation notifications to visually change how the bundle items are presented to the buyer.

Line item script...

```ruby
Input.cart.line_items.each do |line_item|
  if line_item.properties["_is_bundle_item"] == 'yes'
    line_item.change_line_price(line_item.line_price * 0, message: "Included in Bundle")  
  end
end

Output.cart = Input.cart
```